### PR TITLE
Changed background from repeating to single gradient

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4,9 +4,9 @@
   font-family: "Roboto";
 }
 
-body {
-  background-color: #eee;
+html {
   background: radial-gradient(circle, #939292 0%, black 100%);
+  height: 100%;
 }
 
 .container {


### PR DESCRIPTION
## The Issue
Currently, the website has a radial gradient which keeps repeating, due to this there is a sudden break in the smooth background. An alternative is suggested in this fix, which will keep one solid gradient background no matter what the device size is. I have added current and modified version screenshots, but it is to be noted that the screenshots don't show how it is actually, in reality we can see the prominent distinction.

### Current version
![image](https://user-images.githubusercontent.com/26377114/96498126-4a290380-1269-11eb-8ff7-84f476908adb.png)

### Modified version
![image](https://user-images.githubusercontent.com/26377114/96498219-67f66880-1269-11eb-8d2c-6b37633bb67a.png)
